### PR TITLE
[HOTFIX] identify v3 config if greater or equal than v3.0.0 not just equal 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubUtils
 Title: Utility Functions for Infectious Disease Modeling Hubs
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: c(
     person("Anna", "Krystalli", , "annakrystalli@googlemail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2378-4915")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hubUtils 0.1.2
+
+* Bug fix: Corrected bug in v3 config utilities so that configs are detected as `v3` if they are `v3.0.0` or above, not just `v3.0.0`. Thanks to @M-7th for reporting.
+
 # hubUtils 0.1.1
 
 * Remove `hubAdmin` Suggests dependency by moving test hub configuration validation to CI

--- a/R/v3-schema-utils.R
+++ b/R/v3-schema-utils.R
@@ -12,7 +12,7 @@
 #' is_v3_config(config)
 is_v3_config <- function(config) {
   checkmate::assert_list(config)
-  extract_schema_version(config$schema_version) == "v3.0.0"
+  extract_schema_version(config$schema_version) >= "v3.0.0"
 }
 
 #' Is config file using v3.0.0 schema?
@@ -28,7 +28,7 @@ is_v3_config <- function(config) {
 is_v3_config_file <- function(config_path) {
   checkmate::assert_file_exists(config_path)
   config <- read_config_file(config_path)
-  extract_schema_version(config$schema_version) == "v3.0.0"
+  extract_schema_version(config$schema_version) >= "v3.0.0"
 }
 
 #' Is hub configured using v3.0.0 schema?

--- a/tests/testthat/test-v3-schema-utils.R
+++ b/tests/testthat/test-v3-schema-utils.R
@@ -4,13 +4,13 @@ test_that("is_v3_config works", {
   )
   expect_true(is_v3_config(config))
 
-  v3.0.1_config <- config
-  v3.0.1_config$schema_version <- gsub("v3.0.0", "v3.0.1", config$schema_version)
-  expect_true(is_v3_config(v3.0.1_config))
+  v3_0_1_config <- config
+  v3_0_1_config$schema_version <- gsub("v3.0.0", "v3.0.1", config$schema_version)
+  expect_true(is_v3_config(v3_0_1_config))
 
-  v2.0.0_config <- config
-  v2.0.0_config$schema_version <- gsub("v3.0.0", "v2.0.0", config$schema_version)
-  expect_false(is_v3_config(v2.0.0_config))
+  v2_0_0_config <- config
+  v2_0_0_config$schema_version <- gsub("v3.0.0", "v2.0.0", config$schema_version)
+  expect_false(is_v3_config(v2_0_0_config))
 })
 
 test_that("is_v3_config_file works", {

--- a/tests/testthat/test-v3-schema-utils.R
+++ b/tests/testthat/test-v3-schema-utils.R
@@ -3,7 +3,16 @@ test_that("is_v3_config works", {
     system.file("config", "tasks.json", package = "hubUtils")
   )
   expect_true(is_v3_config(config))
+
+  v3.0.1_config <- config
+  v3.0.1_config$schema_version <- gsub("v3.0.0", "v3.0.1", config$schema_version)
+  expect_true(is_v3_config(v3.0.1_config))
+
+  v2.0.0_config <- config
+  v2.0.0_config$schema_version <- gsub("v3.0.0", "v2.0.0", config$schema_version)
+  expect_false(is_v3_config(v2.0.0_config))
 })
+
 test_that("is_v3_config_file works", {
   config_path <- system.file("config", "tasks.json", package = "hubUtils")
   expect_true(is_v3_config_file(config_path))

--- a/tests/testthat/test-v3-schema-utils.R
+++ b/tests/testthat/test-v3-schema-utils.R
@@ -16,6 +16,10 @@ test_that("is_v3_config works", {
 test_that("is_v3_config_file works", {
   config_path <- system.file("config", "tasks.json", package = "hubUtils")
   expect_true(is_v3_config_file(config_path))
+
+  config_path_v3_0_1 <- test_path("testdata", "v3.0.1-tasks.json")
+  expect_true(is_v3_config_file(config_path_v3_0_1))
+
 })
 test_that("is_v3_hub works", {
   expect_false(

--- a/tests/testthat/testdata/v3.0.1-tasks.json
+++ b/tests/testthat/testdata/v3.0.1-tasks.json
@@ -1,0 +1,97 @@
+{
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json",
+    "rounds": [
+        {
+            "round_id_from_variable": true,
+            "round_id": "round_id",
+            "model_tasks": [
+                {
+                    "task_ids": {
+                        "round_id": {
+                            "required": null,
+                            "optional": ["2024_2025_1_COVID", "2024_2025_1_FLU"]
+                        },
+                        "scenario_id": {
+                            "required": null,
+                            "optional": ["A", "B", "C", "D", "E", "F"]
+                        },
+                        "target": {
+                            "required": null,
+                            "optional": ["ILI incidence", "ili_plus"]
+                        },
+                        "location": {
+                            "required": null,
+                            "optional": ["AT","BE","BG","CH","CY","CZ","DE","DK","EE","ES","FI","FR","GR","HR","HU","IE","IS","IT","LI","LT","LU","LV","MT","NL","NO","PL","PT","RO","SE","SI","SK","GB-ENG","GB-WLS","GB-NIR","GB-SCT"]
+                        },
+                        "pop_group": {
+                            "required": null,
+                            "optional": ["0-4_vaxYes", "0-4_vaxNo"]
+                        },
+                        "target_end_date": {
+                            "required": null,
+                            "optional": ["2024-08-11","2024-08-18","2024-08-25","2024-09-01","2024-09-08","2024-09-15","2024-09-22","2024-09-29","2024-10-06","2024-10-13","2024-10-20","2024-10-27","2024-11-03","2024-11-10","2024-11-17","2024-11-24","2024-12-01","2024-12-08","2024-12-15","2024-12-22","2024-12-29","2025-01-05","2025-01-12","2025-01-19","2025-01-26","2025-02-02","2025-02-09","2025-02-16","2025-02-23","2025-03-02","2025-03-09","2025-03-16","2025-03-23","2025-03-30","2025-04-06","2025-04-13","2025-04-20","2025-04-27","2025-05-04","2025-05-11","2025-05-18","2025-05-25","2025-06-01"]
+                        },
+                        "horizon": {
+                            "required": null,
+                            "optional": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43]
+                        }
+                    },
+                    "output_type": {
+                        "sample": {
+                            "output_type_id_params": {
+                               "is_required": true,
+                               "type": "character",
+                               "max_length": 6,
+                               "min_samples_per_task": 1,
+                               "max_samples_per_task": 100,
+                               "compound_taskid_set": ["round_id", "scenario_id", "target", "location", "pop_group"]
+                           },
+                           "value":{
+                               "type": "double",
+                               "minimum": 0
+                           }
+                        },
+                        "quantile": {
+                            "output_type_id": {
+                                "required": null,
+                                "optional": [0.01,0.025,0.05,0.1,0.15,0.2,0.25,0.3,0.35,0.4,0.45,0.5,0.55,0.6,0.65,0.7,0.75,0.8,0.85,0.9,0.95,0.975,0.99]                                
+                            },
+                            "value": {
+                                "type": "double",
+                                "minimum": 0
+                            }
+                        }
+                    },
+                    "target_metadata": [
+                        {
+                           "target_id": "ILI incidence",
+                           "target_name": "Weekly incidence for Influenza like illness",
+                           "target_units": "cases per 100,000 population",
+                           "target_keys": {
+                               "target": "ILI incidence"
+                           },
+                           "description": "This target represents the count of new ILI cases per 100,000 in the week ending on the date [horizon] weeks after the reference_date",
+                           "target_type": "continuous",
+                           "is_step_ahead": true,
+                           "time_unit": "week"
+                        },
+                        {
+                           "target_id": "ili_plus",
+                           "target_name": "Weekly incidence for Influenza like illness",
+                           "target_units": "cases per 100,000 population",
+                           "target_keys": {
+                               "target": "ili_plus"
+                           },
+                           "description": "This target represents the count of new ILI cases per 100,000 in the week ending on the date [horizon] weeks after the reference_date",
+                           "target_type": "continuous",
+                           "is_step_ahead": true,
+                           "time_unit": "week"
+                        }
+                    ]
+                }
+            ],
+            "submissions_due": {"start":"2024-04-14","end":"2024-09-14"}
+        }
+    ],
+    "output_type_id_datatype": "character"
+}


### PR DESCRIPTION
Very silly bug that is affecting important downstream functionality though for hubs using v3.0.1 which is currently not being detected as v3 🙈 

Hence expediting merge.

Bug reported by @M-7th through slack