### PR TITLE
Use package version instead of version string for comparisons

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,8 @@
   - `version_lt()`: Check whether a schema version property is less than.
 * Move `as_config()` from `hubAdmin` to `hubUtils` package (#173).
 * `<config>` class objects now have a `type` attribute to track what type of config they contain (i.e `"tasks"` or `"admin"`).
-* Attempt to convert output of `read_config()` and `read_config_file()` to a `<config>` class object (#173).
+* Attempt to convert output of `read_config()` and `read_config_file()` to a `<config>` class object (#173).`
+* Fix bug in `extract_schema_version()` where only single digits from each version component were being extracted.
   
 
 # hubUtils 0.1.7

--- a/R/check_deprecated_schema.R
+++ b/R/check_deprecated_schema.R
@@ -60,10 +60,3 @@ deprecate_schema_warn <- function(config_version, valid_version, hubutils_versio
     user_env = .GlobalEnv
   )
 }
-
-extract_schema_version <- function(schema_version_url) {
-  stringr::str_extract(
-    schema_version_url,
-    "v([0-9]\\.){2}[0-9](\\.[0-9]+)?"
-  )
-}

--- a/R/utils-schema-versions.R
+++ b/R/utils-schema-versions.R
@@ -82,7 +82,7 @@ version_equal <- function(version, config = NULL, config_path = NULL,
                           hub_path = NULL, schema_version = NULL) {
   validate_version_format(version)
   comp_version <- get_comp_version(config, config_path, hub_path, schema_version)
-  comp_version == version
+  comp_version == as_pkg_version(version)
 }
 
 #' @inheritParams read_config_file
@@ -100,7 +100,7 @@ version_gte <- function(version, config = NULL, config_path = NULL,
                         hub_path = NULL, schema_version = NULL) {
   validate_version_format(version)
   comp_version <- get_comp_version(config, config_path, hub_path, schema_version)
-  comp_version >= version
+  comp_version >= as_pkg_version(version)
 }
 
 #' @inheritParams read_config_file
@@ -118,7 +118,7 @@ version_gt <- function(version, config = NULL, config_path = NULL,
                        hub_path = NULL, schema_version = NULL) {
   validate_version_format(version)
   comp_version <- get_comp_version(config, config_path, hub_path, schema_version)
-  comp_version > version
+  comp_version > as_pkg_version(version)
 }
 
 #' @inheritParams read_config_file
@@ -136,7 +136,7 @@ version_lte <- function(version, config = NULL, config_path = NULL,
                         hub_path = NULL, schema_version = NULL) {
   validate_version_format(version)
   comp_version <- get_comp_version(config, config_path, hub_path, schema_version)
-  comp_version <= version
+  comp_version <= as_pkg_version(version)
 }
 
 #' @inheritParams read_config_file
@@ -154,7 +154,7 @@ version_lt <- function(version, config = NULL, config_path = NULL,
                        hub_path = NULL, schema_version = NULL) {
   validate_version_format(version)
   comp_version <- get_comp_version(config, config_path, hub_path, schema_version)
-  comp_version < version
+  comp_version < as_pkg_version(version)
 }
 
 # Get the schema version from the provided argument
@@ -186,12 +186,14 @@ get_comp_version <- function(config, config_path, hub_path, schema_version,
     cli::cli_abort(abort_msg, call = call)
   }
 
-  switch(arg_names,
+  v <- switch(arg_names,
     config = get_version_config(config),
     config_path = get_version_file(config_path),
     hub_path = get_version_hub(hub_path),
     schema_version = extract_schema_version(schema_version)
   )
+
+  as_pkg_version(v)
 }
 
 validate_version_format <- function(version, call = rlang::caller_env()) {
@@ -203,4 +205,8 @@ validate_version_format <- function(version, call = rlang::caller_env()) {
       call = call
     )
   }
+}
+
+as_pkg_version <- function(version) {
+  package_version(gsub("^v", "", version))
 }

--- a/R/utils-schema.R
+++ b/R/utils-schema.R
@@ -147,5 +147,7 @@ validate_schema_version <- function(schema_version, branch) {
 #' @examples
 #' extract_schema_version("schema_version: v1.0.0")
 extract_schema_version <- function(id) {
-  stringr::str_extract(id, "v([0-9]\\.){2}[0-9](\\.[0-9]+)?")
+  stringr::str_extract(
+    id, "v[0-9]+\\.[0-9]+\\.[0-9]+(\\.9[0-9]+)?"
+  )
 }

--- a/tests/testthat/test-utils-schema-versions.R
+++ b/tests/testthat/test-utils-schema-versions.R
@@ -148,3 +148,25 @@ test_that("version comparison utilities fail correctly", {
     error = TRUE
   )
 })
+
+test_that("version comparisons interpret pkg versions correctly", {
+  schema_version <- "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.11/tasks-schema.json"
+  expect_true(
+    version_gt("v3.0.2", schema_version = schema_version)
+  )
+  expect_true(
+    version_gte("v3.0.2", schema_version = schema_version)
+  )
+  expect_false(
+    version_lte("v3.0.2", schema_version = schema_version)
+  )
+  expect_false(
+    version_lt("v3.0.2", schema_version = schema_version)
+  )
+  expect_false(
+    version_equal("v3.0.0", schema_version = schema_version)
+  )
+  expect_true(
+    version_equal("v3.0.11", schema_version = schema_version)
+  )
+})

--- a/tests/testthat/test-utils-schema.R
+++ b/tests/testthat/test-utils-schema.R
@@ -64,10 +64,6 @@ test_that("check extract_schema_version on multidigit versions", {
       "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.20.13.900004/tasks-schema.json"
     ), "v3.20.13.900004"
   )
-
-
-
-
 })
 
 

--- a/tests/testthat/test-utils-schema.R
+++ b/tests/testthat/test-utils-schema.R
@@ -52,3 +52,22 @@ test_that("extract_schema_version works", {
     ), "v3.0.0"
   )
 })
+
+test_that("check extract_schema_version on multidigit versions", {
+  expect_equal(
+    extract_schema_version(
+      "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.11/tasks-schema.json"
+    ), "v3.0.11"
+  )
+  expect_equal(
+    extract_schema_version(
+      "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.20.13.900004/tasks-schema.json"
+    ), "v3.20.13.900004"
+  )
+
+
+
+
+})
+
+


### PR DESCRIPTION
Resolves #177 

Also fixes bug in `extract_schema_version()` that was incorrectly only extracting single digits from each version component as well as removing erroneous function duplicate.