### PR TITLE
add maturing lifecycle badge

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 <!-- badges: start -->
 
 [![R-CMD-check](https://github.com/hubverse-org/hubUtils/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/hubverse-org/hubUtils/actions/workflows/R-CMD-check.yaml)
-[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![Lifecycle: maturing](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://lifecycle.r-lib.org/articles/stages.html#maturing)
 [![Codecov test coverage](https://codecov.io/gh/hubverse-org/hubUtils/branch/main/graph/badge.svg)](https://app.codecov.io/gh/hubverse-org/hubUtils?branch=main)
 [![CRAN status](https://www.r-pkg.org/badges/version/hubUtils)](https://CRAN.R-project.org/package=hubUtils)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![R-CMD-check](https://github.com/hubverse-org/hubUtils/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/hubverse-org/hubUtils/actions/workflows/R-CMD-check.yaml)
 [![Lifecycle:
-experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+maturing](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://lifecycle.r-lib.org/articles/stages.html#maturing)
 [![Codecov test
 coverage](https://codecov.io/gh/hubverse-org/hubUtils/branch/main/graph/badge.svg)](https://app.codecov.io/gh/hubverse-org/hubUtils?branch=main)
 [![CRAN


### PR DESCRIPTION
this will address #179

Though, the tidyverse team no longer recommends "maturing" as a stage:

> Previously we used as maturing for functions that lay somewhere between experimental and stable. We stopped using this stage because, like questioning, it’s not clear what actionable information this stage delivers.