### PR TITLE
Silence warnings from `as_config` checks by default when reading config files.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,6 @@
 # hubUtils (development version)
 
-* `schema_id` version checks silenced by default in `read_config()` and `read_config_file()`.
-
+* `schema_id` version checks silenced by default in `read_config()` and `read_config_file()`.  
 * Add and export `hubValidations` functions `get_hub_timezone()`, `get_hub_model_output_dir()` and `get_hub_file_formats()`  for extracting hub metadata to `hubUtils` package.
 * Add new function `get_derived_task_ids()` to extract round or hub level derived task ID values from a `tasks.json` config file.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # hubUtils (development version)
 
+* `schema_id` version checks silenced by default in `read_config()` and `read_config_file()`.
+
 * Add and export `hubValidations` functions `get_hub_timezone()`, `get_hub_model_output_dir()` and `get_hub_file_formats()`  for extracting hub metadata to `hubUtils` package.
 * Add new function `get_derived_task_ids()` to extract round or hub level derived task ID values from a `tasks.json` config file.
 

--- a/R/read_config.R
+++ b/R/read_config.R
@@ -28,7 +28,7 @@
 #' read_config(hub_path, "admin")
 read_config <- function(hub_path,
                         config = c("tasks", "admin", "model-metadata-schema"),
-                        silent = FALSE) {
+                        silent = TRUE) {
   UseMethod("read_config")
 }
 
@@ -38,7 +38,7 @@ read_config <- function(hub_path,
 #' @importFrom fs path
 read_config.default <- function(hub_path,
                                 config = c("tasks", "admin", "model-metadata-schema"),
-                                silent = FALSE) {
+                                silent = TRUE) {
   config <- rlang::arg_match(config)
   path <- path(hub_path, "hub-config", config, ext = "json")
 
@@ -57,7 +57,7 @@ read_config.SubTreeFileSystem <- function(hub_path,
                                             "tasks", "admin",
                                             "model-metadata-schema"
                                           ),
-                                          silent = FALSE) {
+                                          silent = TRUE) {
   config <- rlang::arg_match(config)
   path <- hub_path$path(path("hub-config", config, ext = "json")) # nolint: object_usage_linter
 
@@ -89,7 +89,7 @@ read_config.SubTreeFileSystem <- function(hub_path,
 #'
 #' @examples
 #' read_config_file(system.file("config", "tasks.json", package = "hubUtils"))
-read_config_file <- function(config_path, silent = FALSE) {
+read_config_file <- function(config_path, silent = TRUE) {
   config <- jsonlite::fromJSON(
     config_path,
     simplifyVector = TRUE,

--- a/man/read_config.Rd
+++ b/man/read_config.Rd
@@ -7,7 +7,7 @@
 read_config(
   hub_path,
   config = c("tasks", "admin", "model-metadata-schema"),
-  silent = FALSE
+  silent = TRUE
 )
 }
 \arguments{

--- a/man/read_config_file.Rd
+++ b/man/read_config_file.Rd
@@ -4,7 +4,7 @@
 \alias{read_config_file}
 \title{Read a JSON config file from a path}
 \usage{
-read_config_file(config_path, silent = FALSE)
+read_config_file(config_path, silent = TRUE)
 }
 \arguments{
 \item{config_path}{Character string. Path to JSON config file.}

--- a/tests/testthat/_snaps/read_config.md
+++ b/tests/testthat/_snaps/read_config.md
@@ -1071,7 +1071,7 @@
 # read_config_file outputs warning when can't convert to config class
 
     Code
-      read_config_file(test_path("testdata", "empty.json"))
+      read_config_file(test_path("testdata", "empty.json"), silent = FALSE)
     Condition
       Warning:
       Could not convert to <config>: No schema_version property found.
@@ -1081,7 +1081,7 @@
 # read_config_file warning silencing works
 
     Code
-      read_config_file(test_path("testdata", "empty.json"), silent = TRUE)
+      read_config_file(test_path("testdata", "empty.json"))
     Output
       named list()
 

--- a/tests/testthat/test-read_config.R
+++ b/tests/testthat/test-read_config.R
@@ -39,14 +39,12 @@ test_that("read_config_file works", {
 
 test_that("read_config_file outputs warning when can't convert to config class", {
   expect_snapshot(
-    read_config_file(test_path("testdata", "empty.json"))
+    read_config_file(test_path("testdata", "empty.json"), silent = FALSE)
   )
 })
 
 test_that("read_config_file warning silencing works", {
   expect_snapshot(
-    read_config_file(test_path("testdata", "empty.json"),
-      silent = TRUE
-    )
+    read_config_file(test_path("testdata", "empty.json"))
   )
 })


### PR DESCRIPTION
The check on the config `schema_id` property against valid schema versions becomes extremely irritating when developing a new schema. 

While I can see some use for it in`as_config()` itself, It feels like it shouldn't be issuing warnings when reading config files and converting them to config class objects as this validation should have been performed at different stages, not when reading the file. So in this PR, I've set the `silent` argument to `TRUE` in `read_config()` and `read_config_file()`  by default.

However, the checks are still currently performed in `as_config()` and just caught and issued as a warning if any errors are generated. Some of these checks require an internet connection, which also seems excessive for reading a local config file. 

In additions, if any errors are thrown, the `read_config()` and `read_config_file()` still fail to return a `config` class object, however now it does so silently by default. Is this the desired behaviour?

Because of the above lingering unsatisfying behaviour, I've opened an issue to revisit this topic for further refactoring: #191 