### PR TITLE
Set up CODEOWNERS and dependabot and pin third-party actions by commit hash

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# require core team member review for updates to GitHub workflows
+/.github/CODEOWNERS @hubverse-org/hubverse-developers
+/.github/actions/ @hubverse-org/hubverse-developers
+/.github/shared/ @hubverse-org/hubverse-developers
+/.github/workflows/ @hubverse-org/hubverse-developers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# instruct GitHub dependabot to scan github actions for dependency updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # dependabot automatically checks .github/workflows/ and .github/actions/
+    directory: "/"
+    schedule:
+      interval: "weekly"
+

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,10 +44,10 @@ jobs:
           sed -i -e '/  hubverse-org/d' DESCRIPTION
 
       - id: setup-pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@14a7e741c1cb130261263aa1593718ba42cf443b  #v2.11.2
 
       - id: setup-r
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@14a7e741c1cb130261263aa1593718ba42cf443b  #v2.11.2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
@@ -55,12 +55,12 @@ jobs:
           extra-repositories: https://hubverse-org.r-universe.dev
 
       - id: fetch-dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
+        uses: r-lib/actions/setup-r-dependencies@14a7e741c1cb130261263aa1593718ba42cf443b  #v2.11.2
         with:
           extra-packages: any::rcmdcheck
           needs: check
 
       - id: check
-        uses: r-lib/actions/check-r-package@v2
+        uses: r-lib/actions/check-r-package@14a7e741c1cb130261263aa1593718ba42cf443b  #v2.11.2
         with:
           upload-snapshots: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,11 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@14a7e741c1cb130261263aa1593718ba42cf443b  #v2.11.2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@14a7e741c1cb130261263aa1593718ba42cf443b  #v2.11.2
         with:
           extra-packages: any::lintr, local::.
           needs: lint

--- a/.github/workflows/pkgdown-netlify-preview.yaml
+++ b/.github/workflows/pkgdown-netlify-preview.yaml
@@ -29,15 +29,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-tinytex@v2
+      - uses: r-lib/actions/setup-tinytex@14a7e741c1cb130261263aa1593718ba42cf443b  #v2.11.2
 
-      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-pandoc@14a7e741c1cb130261263aa1593718ba42cf443b  #v2.11.2
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@14a7e741c1cb130261263aa1593718ba42cf443b  #v2.11.2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@14a7e741c1cb130261263aa1593718ba42cf443b  #v2.11.2
         with:
           extra-packages: any::pkgdown, local::.
           needs: website

--- a/.github/workflows/pkgdown-netlify-preview.yaml
+++ b/.github/workflows/pkgdown-netlify-preview.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Deploy production to GitHub pages 🚀
         if: contains(env.isPush, 'true')
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8  #v4.7.3
         with:
           clean: false
           branch: gh-pages
@@ -57,7 +57,7 @@ jobs:
       - name: Deploy PR preview to Netlify
         if: contains(env.isPush, 'false')
         id: netlify-deploy
-        uses: nwtgck/actions-netlify@v2
+        uses: nwtgck/actions-netlify@4cbaf4c08f1a7bfa537d6113472ef4424e4eb654  #v3.0.0
         with:
           publish-dir: './docs'
           production-branch: main

--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
     # NO NEED TO CHECKOUT HERE
-    - uses: r-hub/actions/setup@v1
+    - uses: r-hub/actions/setup@beabf049a34955e2627d8811b8f04c1aee4db4b1
       with:
         config: ${{ github.event.inputs.config }}
       id: rhub-setup
@@ -51,16 +51,16 @@ jobs:
       image: ${{ matrix.config.container }}
 
     steps:
-      - uses: r-hub/actions/checkout@v1
-      - uses: r-hub/actions/platform-info@v1
+      - uses: r-hub/actions/checkout@beabf049a34955e2627d8811b8f04c1aee4db4b1
+      - uses: r-hub/actions/platform-info@beabf049a34955e2627d8811b8f04c1aee4db4b1
         with:
           token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
-      - uses: r-hub/actions/setup-deps@v1
+      - uses: r-hub/actions/setup-deps@beabf049a34955e2627d8811b8f04c1aee4db4b1
         with:
           token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
-      - uses: r-hub/actions/run-check@v1
+      - uses: r-hub/actions/run-check@beabf049a34955e2627d8811b8f04c1aee4db4b1
         with:
           token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
@@ -76,20 +76,20 @@ jobs:
         config: ${{ fromJson(needs.setup.outputs.platforms) }}
 
     steps:
-      - uses: r-hub/actions/checkout@v1
-      - uses: r-hub/actions/setup-r@v1
+      - uses: r-hub/actions/checkout@beabf049a34955e2627d8811b8f04c1aee4db4b1
+      - uses: r-hub/actions/setup-r@beabf049a34955e2627d8811b8f04c1aee4db4b1
         with:
           job-config: ${{ matrix.config.job-config }}
           token: ${{ secrets.RHUB_TOKEN }}
-      - uses: r-hub/actions/platform-info@v1
+      - uses: r-hub/actions/platform-info@beabf049a34955e2627d8811b8f04c1aee4db4b1
         with:
           token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
-      - uses: r-hub/actions/setup-deps@v1
+      - uses: r-hub/actions/setup-deps@beabf049a34955e2627d8811b8f04c1aee4db4b1
         with:
           job-config: ${{ matrix.config.job-config }}
           token: ${{ secrets.RHUB_TOKEN }}
-      - uses: r-hub/actions/run-check@v1
+      - uses: r-hub/actions/run-check@beabf049a34955e2627d8811b8f04c1aee4db4b1
         with:
           job-config: ${{ matrix.config.job-config }}
           token: ${{ secrets.RHUB_TOKEN }}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -17,12 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@14a7e741c1cb130261263aa1593718ba42cf443b  #v2.11.2
         with:
           use-public-rspm: true
           extra-repositories: https://hubverse-org.r-universe.dev
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@14a7e741c1cb130261263aa1593718ba42cf443b  #v2.11.2
         with:
           extra-packages: any::covr
           needs: coverage

--- a/.github/workflows/validate-flusight-testhub-config.yaml
+++ b/.github/workflows/validate-flusight-testhub-config.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@14a7e741c1cb130261263aa1593718ba42cf443b  #v2.11.2
         with:
           install-r: false
           use-public-rspm: true
@@ -29,7 +29,7 @@ jobs:
         run: |
           sudo apt-get update
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@14a7e741c1cb130261263aa1593718ba42cf443b  #v2.11.2
         with:
           cache: 'always'
           packages: |

--- a/.github/workflows/validate-flusight-testhub-config.yaml
+++ b/.github/workflows/validate-flusight-testhub-config.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: "Comment on PR"
         id: comment-diff
         if: ${{ github.event_name != 'workflow_dispatch' }}
-        uses: carpentries/actions/comment-diff@main
+        uses: carpentries/actions/comment-diff@e27aa6c531dadd357d2aa4c9a21e90849e23e963  #v0.14.0
         with:
           pr: ${{ env.PR_NUMBER }}
           path: ${{ env.HUB_PATH }}/diff.md

--- a/.github/workflows/validate-simple-testhub-config.yaml
+++ b/.github/workflows/validate-simple-testhub-config.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@14a7e741c1cb130261263aa1593718ba42cf443b  #v2.11.2
         with:
           install-r: false
           use-public-rspm: true
@@ -29,7 +29,7 @@ jobs:
         run: |
           sudo apt-get update
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@14a7e741c1cb130261263aa1593718ba42cf443b  #v2.11.2
         with:
           cache: 'always'
           packages: |

--- a/.github/workflows/validate-simple-testhub-config.yaml
+++ b/.github/workflows/validate-simple-testhub-config.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: "Comment on PR"
         id: comment-diff
         if: ${{ github.event_name != 'workflow_dispatch' }}
-        uses: carpentries/actions/comment-diff@main
+        uses: carpentries/actions/comment-diff@e27aa6c531dadd357d2aa4c9a21e90849e23e963  #v0.14.0
         with:
           pr: ${{ env.PR_NUMBER }}
           path: ${{ env.HUB_PATH }}/diff.md


### PR DESCRIPTION
This PR can be reviewed commit by commit and does the following:

- Add CODEOWNERS to monitor GitHub workflow updates
- Set up Dependabot to flag updates to GitHub actions
- Pin 3rd party GitHub actions via commit SHA