### PR TITLE
Ls/convert output type supports dependent output type ids/222

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,8 +36,10 @@ Imports:
     memoise,
     purrr,
     rlang,
+    stats,
     stringr,
     tibble,
+    tidyr,
     utils
 Suggests: 
     arrow (>= 17.0.0),

--- a/R/convert_output_types.R
+++ b/R/convert_output_types.R
@@ -117,7 +117,6 @@ validate_conversion_inputs <- function(model_out_tbl, terminal_output_type,
   # check model_out_tbl contains the "model_id" column
   # otherwise, coercion to model_out_tbl will fail
   model_out_cols <- colnames(model_out_tbl)
-  task_id_cols <- subset_task_id_names(model_out_cols)
   if (!("model_id" %in% model_out_cols)) {
     cli::cli_abort(c("Provided {.arg model_output_tbl} must contain the column {.val {'model_id'}}"))
   }
@@ -152,7 +151,7 @@ validate_conversion_inputs <- function(model_out_tbl, terminal_output_type,
     ~ validate_terminal_output_type_id(
       terminal_output_type = .x,
       terminal_output_type_id = terminal_output_type_id[[.x]],
-      task_id_cols
+      task_id_cols = subset_task_id_names(model_out_cols)
     )
   )
 

--- a/tests/testthat/test-convert_output_types.R
+++ b/tests/testthat/test-convert_output_types.R
@@ -70,7 +70,10 @@ test_that("providing incompatible output_type_ids throws an error", {
 
   # data frame terminal_output_type_id contains the required columns
   expect_error(
-    convert_output_type(sample_outputs, terminal_output_type_id = list("quantile" = data.frame(value = c(0.25, 0.5, 0.75)))),
+    convert_output_type(
+      sample_outputs,
+      terminal_output_type_id = list("quantile" = data.frame(value = c(0.25, 0.5, 0.75)))
+    ),
     "`terminal_output_type_id` did not contain the required column ", fixed = TRUE
   )
   # data frame terminal_output_type_id includes task IDs not present in


### PR DESCRIPTION
Taken from #222:
> Sometimes, we may want to convert to a different output type in which the output type IDs are dependent on certain task ID variables. There are two ways in which this dependency will play out:
> 
> 1. Different sets of output type id levels dependent on the modeling task
>    
>    * e.g. different quantile levels for different targets
>    * Could be for any (probabilistic) output types: quantile, CDF, PMF, maybe samples
>    * Seems most common for different targets, but could be for other tasks
> 2. Different definitions for the same output type id levels, dependent on the modeling task
>    
>    * e.g. pmf bin categories are defined differently based on location and/or horizon, etc
>    * Only possible for PMF output type as of now

Here, we are still ONLY supporting conversions from sample to mean, median, and quantile by changing their implementation so that case (1) described above is supported. This is done in such a way that generalize is the calculations so that case (2) may also be implemented with ease later. The code workflow is as follows:
1. Validate the inputs to `convert_output_type()`
2. Iterate over the requested terminal output types, performing one conversion at a time using `map()`
3. Group the model outputs by model ID and the task ID columns
4. Based on the requested terminal output type, set values for: 
  a. The columns specifying information about the terminal output type ID (`otid_cols`). These will always be just `"output_type_id"` for all output types other than PMF, which will have values `c("output_type_id", "lower", "upper")`
  b. The transformation function to be used (`transform_fun`)
  c. The arguments to be fed into that transformation, often columns of values (`transform_args`)
5. Summarize the model outputs so that every unique combination of task ID variables for each model stores the associated forecast values as a list to later be transformed using `transform_fun`
6. Do some form of "joining" the summarized model outputs the terminal output type id vector or data frame
  a. If the output type ids are dependent on task ID values, perform a left join
  b. Else, mutate a nested output_type_id column containing the terminal output type id values, then unnest
7. Calculate the transformed forecast values by calling `transform_fun` with its arguments `transform_args` via `do.call()`
8. Cleanup the forecasts and ensure the tabular predictions contain all necessary columns in a model_out_tbl
9. Bind all of the transformed forecasts together if multiple transformations are requested and coerce to a model_out_tbl