### PR TITLE
znk/pin carp/224

### DIFF
--- a/.github/workflows/validate-flusight-testhub-config.yaml
+++ b/.github/workflows/validate-flusight-testhub-config.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: "Comment on PR"
         id: comment-diff
         if: ${{ github.event_name != 'workflow_dispatch' }}
-        uses: carpentries/actions/comment-diff@main
+        uses: carpentries/actions/comment-diff@2e20fd5ee53b691e27455ce7ca3b16ea885140e8 #v0.15.0
         with:
           pr: ${{ env.PR_NUMBER }}
           path: ${{ env.HUB_PATH }}/diff.md

--- a/.github/workflows/validate-simple-testhub-config.yaml
+++ b/.github/workflows/validate-simple-testhub-config.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: "Comment on PR"
         id: comment-diff
         if: ${{ github.event_name != 'workflow_dispatch' }}
-        uses: carpentries/actions/comment-diff@main
+        uses: carpentries/actions/comment-diff@2e20fd5ee53b691e27455ce7ca3b16ea885140e8 #v0.15.0
         with:
           pr: ${{ env.PR_NUMBER }}
           path: ${{ env.HUB_PATH }}/diff.md

--- a/inst/schemas/update.json
+++ b/inst/schemas/update.json
@@ -1,5 +1,5 @@
 {
   "branch": "main",
-  "sha": "9f6fb38d4b021c153dd4cfaf6d9033fcd07c68f2",
-  "timestamp": "2025-01-22T07:16:10Z"
+  "sha": "da1b85bce2b20f6350509b2afd07492f1aa5bf79",
+  "timestamp": "2025-04-04T13:37:50Z"
 }

--- a/inst/schemas/v5.0.0/tasks-schema.json
+++ b/inst/schemas/v5.0.0/tasks-schema.json
@@ -1182,7 +1182,7 @@
                                                 "maxLength": 100
                                             },
                                             "target_keys": {
-                                                "description": "Should be either null, in the case where the target is not specified as a task_id and is specified solely through the target_id target_metadata property or an object with one or more properties, the names of which match task_id variable(s) named within the same model_tasks object. Each property should have one specified value. Each value, or the combination of values if multiple keys are specified, define a single target value.",
+                                                "description": "Should be either null, in the case where the target is not specified as a task_id and is specified solely through the target_id target_metadata property or an object with a single property. The property name must match a task_id variable defined within the same model_tasks object and should have a single specified value, which matches one of the values in the associated task ID variable. This value defines a single target.",
                                                 "examples": [
                                                     {
                                                         "target": "inc hosp"


### PR DESCRIPTION
- **pin carpentries action**
  This will fix #224
  

- **update schema via pre-push hook**
  This is an update from the synchronization script:
  <https://github.com/hubverse-org/hubUtils/blob/main/.github/CONTRIBUTING.md#synchronizing-with-hubverse-orgschemas>
  
  In https://github.com/hubverse-org/schemas/pull/122, the description for
  the tasks schema was updated to clarify in the schema docs that multiple
  target keys. This is a valid update since, while we use releases to
  indicate a schema release, the hubs all pull the schema from the main
  branch.
  
  This also shows a bit of a weakness with git hooks: they only work if
  people actually install them.
  
  The reason I found this was because
  https://github.com/hubverse-org/hubUtils/pull/218 modified the return
  statements and the hook informed me that it was outdated. When I
  updated it, the schemas updated.
  