### PR TITLE
Update links to docs.hubverse.io

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -38,11 +38,11 @@ Examples of unacceptable behavior include:
 
 ## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying our standards of acceptable behavior. Enforcement is the responsibility of the [Code of Conduct Committee](https://hubverse.io/en/latest/coc/committee.html), who will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. 
+Community leaders are responsible for clarifying our standards of acceptable behavior. Enforcement is the responsibility of the [Code of Conduct Committee](https://docs.hubverse.io/en/latest/coc/committee.html), who will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. 
 
-Instances of abusive, harassing, or otherwise unacceptable behavior [may be reported to any member of the Code of Conduct Committee](https://hubverse.io/en/latest/coc/committee.html). All complaints will be reviewed and investigated promptly and fairly. 
+Instances of abusive, harassing, or otherwise unacceptable behavior [may be reported to any member of the Code of Conduct Committee](https://docs.hubverse.io/en/latest/coc/committee.html). All complaints will be reviewed and investigated promptly and fairly. 
 
-The Code of Conduct Committee will use the [Enforcement Manual](https://hubverse.io/en/latest/coc/enforcement-manual.html) in determining the consequences for any action they deem in violation of this Code of Conduct. All community leaders and Code of Conduct Committee members are obligated to respect the privacy and security of the reporter of any incident.
+The Code of Conduct Committee will use the [Enforcement Manual](https://docs.hubverse.io/en/latest/coc/enforcement-manual.html) in determining the consequences for any action they deem in violation of this Code of Conduct. All community leaders and Code of Conduct Committee members are obligated to respect the privacy and security of the reporter of any incident.
 
 
 ## Scope

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 This outlines how to propose a change to `hubUtils`.
 For more general info about contributing to this, and other hubverse packages, please see the
-[**hubverse contributing guide**](https://hubverse.io/en/latest/overview/contribute.html).
+[**hubverse contributing guide**](https://docs.hubverse.io/en/latest/overview/contribute.html).
 
 You can fix typos, spelling mistakes, or grammatical errors in the documentation directly using the GitHub web interface, as long as the changes are made in the *source* file.
 This generally means you'll need to edit [roxygen2 comments](https://roxygen2.r-lib.org/articles/roxygen2.html) in an `.R`, not a `.Rd` file.

--- a/R/utils-url.R
+++ b/R/utils-url.R
@@ -46,7 +46,7 @@ create_s3_url <- function(base_fs, base_path) {
 #' @export
 #'
 #' @examples
-#' is_url("https://hubverse.io")
+#' is_url("https://docs.hubverse.io")
 #' is_url("www.hubverse.io")
 is_url <- function(x) {
   grepl("^(https?|ftp)://[[:alnum:].-]+\\.[a-z]{2,6}(/.*)?$",
@@ -63,8 +63,8 @@ is_url <- function(x) {
 #' @export
 #'
 #' @examples
-#' is_valid_url("https://hubverse.io")
-#' is_valid_url("https://hubverse.io/invalid")
+#' is_valid_url("https://docs.hubverse.io")
+#' is_valid_url("https://docs.hubverse.io/invalid")
 is_valid_url <- function(url) {
   checkmate::assert_character(url, len = 1L)
   if (!curl::has_internet()) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -59,6 +59,6 @@ Please note that the hubUtils package is released with a [Contributor Code of Co
 ## Contributing
 
 Interested in contributing back to the open-source hubverse project?
-Learn more about how to [get involved in the Hubverse Community](https://hubverse.io/en/latest/overview/contribute.html) or [how to contribute to the hubUtils package](https://hubverse-org.github.io/hubUtils/CONTRIBUTING.html).
+Learn more about how to [get involved in the Hubverse Community](https://docs.hubverse.io/en/latest/overview/contribute.html) or [how to contribute to the hubUtils package](https://hubverse-org.github.io/hubUtils/CONTRIBUTING.html).
 
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,6 @@ By contributing to this project, you agree to abide by its terms.
 
 Interested in contributing back to the open-source hubverse project?
 Learn more about how to [get involved in the Hubverse
-Community](https://hubverse.io/en/latest/overview/contribute.html) or
+Community](https://docs.hubverse.io/en/latest/overview/contribute.html) or
 [how to contribute to the hubUtils
 package](https://hubverse-org.github.io/hubUtils/CONTRIBUTING.html).

--- a/man/is_url.Rd
+++ b/man/is_url.Rd
@@ -17,6 +17,6 @@ Logical. \code{TRUE} if \code{x} is a URL, \code{FALSE} otherwise.
 Determine if a string is a URL
 }
 \examples{
-is_url("https://hubverse.io")
+is_url("https://docs.hubverse.io")
 is_url("www.hubverse.io")
 }

--- a/man/is_valid_url.Rd
+++ b/man/is_valid_url.Rd
@@ -16,6 +16,6 @@ Logical. \code{TRUE} if the URL is valid and reachable, \code{FALSE} otherwise.
 Determine if a URL is valid and reachable
 }
 \examples{
-is_valid_url("https://hubverse.io")
-is_valid_url("https://hubverse.io/invalid")
+is_valid_url("https://docs.hubverse.io")
+is_valid_url("https://docs.hubverse.io/invalid")
 }

--- a/tests/testthat/test-utils-url.R
+++ b/tests/testthat/test-utils-url.R
@@ -1,17 +1,17 @@
 test_that("is_url works", {
-  expect_true(is_url("https://hubverse.io"))
+  expect_true(is_url("https://docs.hubverse.io"))
   expect_false(is_url("www.hubverse.io"))
 })
 
 test_that("is_valid_url works", {
   skip_if_offline()
-  expect_true(is_valid_url("https://hubverse.io"))
+  expect_true(is_valid_url("https://docs.hubverse.io"))
   expect_true(
     is_valid_url(
       "https://hubverse.s3.amazonaws.com/hubutils/testhubs/simple/hub-config/admin.json"
     )
   )
-  expect_false(is_valid_url("https://hubverse.io/invalid"))
+  expect_false(is_valid_url("https://docs.hubverse.io/invalid"))
   expect_false(
     is_valid_url(
       "https://hubverse.s3.amazonaws.com/hubutils/testhubs/simple/random-file"
@@ -74,7 +74,7 @@ test_that("GitHub utils work", {
   file_url <- "https://github.com/hubverse-org/schemas/tree/main/v5.0.0"
   expect_true(is_github_url(hub_url))
 
-  expect_false(is_github_url("https://hubverse.io"))
+  expect_false(is_github_url("https://docs.hubverse.io"))
   raw_url <- paste0(
     "https://raw.githubusercontent.com/hubverse-org/",
     "example-simple-forecast-hub/refs/heads/main/hub-config/tasks.json"


### PR DESCRIPTION
This PR updates `hubverse.io` URLs to point to `docs.hubverse.io`.

📝 Multiple commits — feel free to **Squash and Merge** to keep history clean.