### PR TITLE
Fix lintr warnings: use native pipe and remove explicit returns

### DIFF
--- a/R/as_config.R
+++ b/R/as_config.R
@@ -59,7 +59,7 @@ validate_config_properties <- function(
       call = call
     )
   }
-  return(TRUE)
+  TRUE
 }
 
 
@@ -127,7 +127,7 @@ validate_schema_url_prefix <- function(
       fixed = TRUE
     )
   }
-  return(invisible(schema_url))
+  invisible(schema_url)
 }
 
 extract_config_type <- function(schema_version) {

--- a/R/as_model_out_tbl.R
+++ b/R/as_model_out_tbl.R
@@ -75,7 +75,7 @@ as_model_out_tbl <- function(
 
   tbl <- std_col_order_model_out_tbl(tbl)
 
-  structure(tbl, class = c("model_out_tbl", class(tbl))) %>%
+  structure(tbl, class = c("model_out_tbl", class(tbl))) |>
     validate_model_out_tbl()
 }
 
@@ -138,7 +138,7 @@ rename_columns <- function(
     value_col <- validate_col_input(value_col, call = call)
     tbl <- rename_col(tbl, value_col, old_names, call)
   }
-  return(tbl)
+  tbl
 }
 
 validate_col_input <- function(x, call = rlang::caller_env()) {
@@ -158,7 +158,7 @@ validate_col_input <- function(x, call = rlang::caller_env()) {
     )
     x <- x[1]
   }
-  return(x)
+  x
 }
 
 rename_col <- function(x, col_name, old_names, call) {
@@ -218,7 +218,7 @@ trim_tbl_to_task_ids <- function(
   }
   task_id_cols <- task_id_cols[task_id_cols %in% names(tbl)]
 
-  return(tbl[, c(task_id_cols, std_colnames)])
+  tbl[, c(task_id_cols, std_colnames)]
 }
 
 remove_model_out_tbl_empty <- function(tbl) {

--- a/R/model_id_merge.R
+++ b/R/model_id_merge.R
@@ -30,8 +30,8 @@
 model_id_merge <- function(tbl, sep = "-") {
   # check all required columns present
   if (!all(c("model_abbr", "team_abbr") %in% names(tbl))) {
+    # nolint next: object_usage_linter
     missing_cols <- c("model_abbr", "team_abbr")[
-      # nolint: object_usage_linter
       !c("model_abbr", "team_abbr") %in% names(tbl)
     ]
     cli::cli_abort(c(
@@ -70,7 +70,7 @@ model_id_merge <- function(tbl, sep = "-") {
   col_order <- names(tbl)[names(tbl) != "model_id"]
   tbl <- tbl[, c("model_id", col_order)]
 
-  return(tbl)
+  tbl
 }
 
 #' @return a [tibble][tibble::tibble()] with `model_id` column split into separate
@@ -88,8 +88,8 @@ model_id_split <- function(tbl, sep = "-") {
   }
   # create model_abbr team_abbr columns
   if (any(c("model_abbr", "team_abbr") %in% names(tbl))) {
+    # nolint next: object_usage_linter
     existing_cols <- c("model_abbr", "team_abbr")[
-      # nolint: object_usage_linter
       !c("model_abbr", "team_abbr") %in% names(tbl)
     ]
     cli::cli_alert_warning(
@@ -122,5 +122,5 @@ model_id_split <- function(tbl, sep = "-") {
   col_order <- names(tbl)[!names(tbl) %in% c("team_abbr", "model_abbr")]
   tbl <- tbl[, c("team_abbr", "model_abbr", col_order)]
 
-  return(tbl)
+  tbl
 }

--- a/R/read_config.R
+++ b/R/read_config.R
@@ -105,7 +105,7 @@ read_config.SubTreeFileSystem <- function(
     hub_path$base_path,
     "/",
     2
-  ) %>%
+  ) |>
     unlist()
 
   path_url <- glue::glue(

--- a/R/utils-config.R
+++ b/R/utils-config.R
@@ -13,8 +13,8 @@ get_task_id_names <- function(config_tasks) {
   purrr::map(
     config_tasks[["rounds"]],
     ~ .x[["model_tasks"]]
-  ) %>%
-    purrr::map(~ names(.x[[1]][["task_ids"]])) %>%
-    unlist() %>%
+  ) |>
+    purrr::map(~ names(.x[[1]][["task_ids"]])) |>
+    unlist() |>
     unique()
 }

--- a/R/utils-round-config.R
+++ b/R/utils-round-config.R
@@ -9,9 +9,9 @@
 #' get_round_task_id_names(config_tasks, round_id = "2022-10-08")
 #' get_round_task_id_names(config_tasks, round_id = "2022-10-15")
 get_round_task_id_names <- function(config_tasks, round_id) {
-  get_round_model_tasks(config_tasks, round_id) %>%
-    purrr::map(~ names(.x[["task_ids"]])) %>%
-    unlist() %>%
+  get_round_model_tasks(config_tasks, round_id) |>
+    purrr::map(~ names(.x[["task_ids"]])) |>
+    unlist() |>
     unique()
 }
 

--- a/R/utils-round_ids.R
+++ b/R/utils-round_ids.R
@@ -28,8 +28,8 @@
 get_round_idx <- function(config_tasks, round_id) {
   checkmate::assert_string(round_id)
   round_id <- rlang::arg_match(round_id, values = get_round_ids(config_tasks))
-  get_round_ids(config_tasks, flatten = "model_task") %>%
-    purrr::map_lgl(~ round_id %in% .x) %>%
+  get_round_ids(config_tasks, flatten = "model_task") |>
+    purrr::map_lgl(~ round_id %in% .x) |>
     which()
 }
 

--- a/R/utils-schema.R
+++ b/R/utils-schema.R
@@ -51,7 +51,7 @@ get_schema_valid_versions <- function(branch = "main") {
   }
   branches <- gh(
     "GET /repos/hubverse-org/schemas/branches"
-  ) %>%
+  ) |>
     vapply("[[", "", "name")
 
   if (!branch %in% branches) {
@@ -114,8 +114,8 @@ get_schema <- function(schema_url) {
   }
 
   if (response$status_code == 200L) {
-    response$content %>%
-      rawToChar() %>%
+    response$content |>
+      rawToChar() |>
       jsonlite::prettify()
   } else {
     cli::cli_abort(
@@ -168,8 +168,8 @@ get_schema_version_latest <- function(
   branch = "main"
 ) {
   if (schema_version == "latest") {
-    get_schema_valid_versions(branch = branch) %>%
-      sort() %>%
+    get_schema_valid_versions(branch = branch) |>
+      sort() |>
       utils::tail(1)
   } else {
     schema_version

--- a/R/v3-schema-utils.R
+++ b/R/v3-schema-utils.R
@@ -40,6 +40,6 @@ is_v3_config_file <- function(config_path) {
 #' is_v3_hub(hub_path = system.file("testhubs", "flusight", package = "hubUtils"))
 is_v3_hub <- function(hub_path, config = c("tasks", "admin", "target-data")) {
   config <- rlang::arg_match(config)
-  read_config(hub_path, config = config) %>%
+  read_config(hub_path, config = config) |>
     is_v3_config()
 }

--- a/data-raw/hub_con_output.R
+++ b/data-raw/hub_con_output.R
@@ -1,9 +1,9 @@
 ## code to prepare `hub_con_output` dataset goes here
 hub_path <- system.file("testhubs/flusight", package = "hubUtils")
 hub_con <- hubData::connect_hub(hub_path)
-hub_con_output <- hub_con %>%
-  dplyr::filter(output_type == "quantile", location == "US") %>%
-  dplyr::collect() %>%
+hub_con_output <- hub_con |>
+  dplyr::filter(output_type == "quantile", location == "US") |>
+  dplyr::collect() |>
   dplyr::filter(forecast_date == max(forecast_date))
 
 


### PR DESCRIPTION
## Summary

- Replace magrittr pipe (`%>%`) with native pipe (`|>`) throughout codebase
- Remove explicit `return()` statements (use implicit returns per tidyverse style)
- Fix `# nolint` comment placement for `object_usage_linter` false positives

## Context

The lint workflow was failing due to changes in lintr v3.3.0+ which enabled new default linters. This PR addresses all warnings to get the workflow passing again.

Closes #271