### PR TITLE
Improve error handling for unavailable internet resources

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # hubUtils (development version)
 
+* Improved error handling when internet resources are unavailable. Functions that access remote URLs now fail gracefully with informative error messages (#272).
+
 # hubUtils 1.1.0
 
 * Added utility functions for extracting properties from `target-data.json` configuration files (v6.0.0 schema):

--- a/R/read_config.R
+++ b/R/read_config.R
@@ -195,10 +195,27 @@ read_json_config <- function(path, silent = TRUE) {
       "Config file {.path {path}} is not a JSON file."
     )
   }
-  config <- jsonlite::fromJSON(
-    path,
-    simplifyVector = TRUE,
-    simplifyDataFrame = FALSE
+  config <- tryCatch(
+    fromJSON(
+      path,
+      simplifyVector = TRUE,
+      simplifyDataFrame = FALSE
+    ),
+    error = function(e) {
+      if (is_url(path)) {
+        cli::cli_abort(c(
+          "x" = "Failed to read config file from {.path {path}}.",
+          "i" = "The URL may be unavailable or there may be
+                 a problem with your internet connection.",
+          "!" = "Error: {e$message}"
+        ))
+      } else {
+        cli::cli_abort(c(
+          "x" = "Failed to read config file {.path {path}}.",
+          "!" = "Error: {e$message}"
+        ))
+      }
+    }
   )
   if (grepl("model-metadata-schema", path)) {
     return(config)

--- a/R/utils-schema.R
+++ b/R/utils-schema.R
@@ -49,10 +49,19 @@ get_schema_valid_versions <- function(branch = "main") {
     schema_path <- system.file("schemas", package = "hubUtils")
     return(list.files(schema_path, pattern = "^v"))
   }
-  branches <- gh(
-    "GET /repos/hubverse-org/schemas/branches"
-  ) |>
-    vapply("[[", "", "name")
+  branches <- tryCatch(
+    gh(
+      "GET /repos/hubverse-org/schemas/branches"
+    ) |>
+      vapply("[[", "", "name"),
+    error = function(e) {
+      cli::cli_abort(c(
+        "x" = "Failed to connect to GitHub API to
+               retrieve schema repository branch information.",
+        "i" = "Please check your internet connection."
+      ))
+    }
+  )
 
   if (!branch %in% branches) {
     cli::cli_abort(c(
@@ -62,9 +71,18 @@ get_schema_valid_versions <- function(branch = "main") {
     ))
   }
 
-  req <- gh(
-    "GET /repos/hubverse-org/schemas/git/trees/{branch}",
-    branch = branch
+  req <- tryCatch(
+    gh(
+      "GET /repos/hubverse-org/schemas/git/trees/{branch}",
+      branch = branch
+    ),
+    error = function(e) {
+      cli::cli_abort(c(
+        "x" = "Failed to connect to GitHub API to
+               retrieve schema version information.",
+        "i" = "Please check your internet connection."
+      ))
+    }
   )
 
   types <- vapply(req$tree, "[[", "", "type")

--- a/tests/testthat/test-read_config.R
+++ b/tests/testthat/test-read_config.R
@@ -133,3 +133,16 @@ test_that("read_config works on target-data.json files", {
     )
   )
 })
+
+test_that("read_config_file fails gracefully when URL unavailable", {
+  local_mocked_bindings(
+    fromJSON = function(...) stop("cannot open connection"),
+    is_valid_url = function(...) TRUE
+  )
+  expect_error(
+    read_config_file(
+      "https://raw.githubusercontent.com/hubverse-org/example-simple-forecast-hub/main/hub-config/tasks.json"
+    ),
+    regexp = "URL may be unavailable"
+  )
+})

--- a/tests/testthat/test-utils-schema.R
+++ b/tests/testthat/test-utils-schema.R
@@ -1,4 +1,5 @@
 test_that("Schema URL created successfully", {
+  skip_if_offline()
   schema_url <- get_schema_url("tasks", "v0.0.1")
   expect_true(valid_url(schema_url))
   expect_equal(
@@ -8,6 +9,7 @@ test_that("Schema URL created successfully", {
 })
 
 test_that("Invalid branches fail successfully", {
+  skip_if_offline()
   expect_error(
     get_schema_url("tasks", "v0.0.1", branch = "random-branch"),
     regexp = "is not a valid branch in schema repository"
@@ -16,6 +18,7 @@ test_that("Invalid branches fail successfully", {
 
 
 test_that("outdated hubUtils will still fetch schema", {
+  skip_if_offline()
   url <- "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.3.3/tasks-schema.json"
   # we should attempt to reach github with missing versions (even if they 404)
   expect_error(
@@ -26,6 +29,7 @@ test_that("outdated hubUtils will still fetch schema", {
 
 
 test_that("Valid json schema versions detected successfully", {
+  skip_if_offline()
   expect_equal(
     get_schema_valid_versions(branch = "hubUtils-test"),
     c("v0.0.0.8", "v0.0.0.9")
@@ -33,6 +37,7 @@ test_that("Valid json schema versions detected successfully", {
 })
 
 test_that("get_schema_version_latest works", {
+  skip_if_offline()
   expect_equal(
     get_schema_version_latest(branch = "hubUtils-test"),
     "v0.0.0.9"
@@ -47,6 +52,7 @@ test_that("get_schema_version_latest works", {
 })
 
 test_that("validate_schema_version works", {
+  skip_if_offline()
   expect_equal(
     validate_schema_version("v0.0.0.9", branch = "hubUtils-test"),
     "v0.0.0.9"
@@ -119,5 +125,15 @@ test_that("Schema URL for target-data created successfully", {
   expect_equal(
     schema_url,
     "https://raw.githubusercontent.com/hubverse-org/schemas/main/v6.0.0/target-data-schema.json"
+  )
+})
+
+test_that("get_schema_valid_versions fails gracefully when GitHub API unavailable", {
+  local_mocked_bindings(
+    gh = function(...) stop("Failed to connect to api.github.com")
+  )
+  expect_error(
+    get_schema_valid_versions(branch = "some-branch"),
+    regexp = "Failed to connect to GitHub API"
   )
 })


### PR DESCRIPTION
## Summary

- Wrap `gh()` calls in `get_schema_valid_versions()` with `tryCatch()` for graceful failure
- Wrap `fromJSON()` in `read_json_config()` with `tryCatch()` for graceful failure  
- Add `skip_if_offline()` to tests that make real network calls
- Add tests for graceful failure when network is unavailable

## Context

CRAN policy requires packages to fail gracefully with informative messages when internet resources are unavailable. This PR addresses warnings received from CRAN (deadline: 2026-01-15).

Closes #272