### PR TITLE
Speed up convert_output_type() by avoiding intermediate expansion (#282)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # hubUtils (development version)
 
+* Substantially improved the performance of `convert_output_type()`. Conversions are now computed per group of model/task ID combinations without first materialising an `n_samples * n_output_type_ids` intermediate table, reducing both runtime and memory allocation by roughly an order of magnitude for large sample tables (#282, thanks @damonbayer for reporting!).
+
 # hubUtils 1.2.0
 
 * Improved error handling when internet resources are unavailable. Functions that access remote URLs now fail gracefully with informative error messages (#272).

--- a/R/convert_output_type.R
+++ b/R/convert_output_type.R
@@ -69,52 +69,79 @@ convert_output_type <- function(model_out_tbl, to) {
 }
 
 #' Convert single output type
+#'
+#' We group the samples by model and task ID variables and compute the
+#' converted output type for each group directly. Crucially, the sample
+#' `value` vector is never duplicated per requested output type ID (as it
+#' would be by an intermediate cross/many-to-many join), which keeps memory
+#' usage and runtime proportional to the input rather than to
+#' `n_samples * n_output_type_ids`.
 #' @noRd
 #' @importFrom rlang .data
 convert_single_output_type <- function(to_output_type, to, model_out_tbl) {
   model_out_cols <- colnames(model_out_tbl)
   task_id_cols <- subset_task_id_names(model_out_cols)
   to_output_type_id <- to[[to_output_type]]
-  otid_cols <- "output_type_id"
+  group_cols <- c("model_id", task_id_cols)
+
+  # task ID columns shared with `to` are used to look up output type IDs that
+  # depend on task ID variable values; otherwise the same IDs apply throughout
+  join_cols <- task_id_cols[task_id_cols %in% colnames(to_output_type_id)]
+
+  grouped <- dplyr::group_by(
+    model_out_tbl,
+    dplyr::across(dplyr::all_of(group_cols))
+  )
 
   if (to_output_type %in% c("mean", "median")) {
     transform_fun <- match.fun(to_output_type)
-    transform_args <- list(x = quote(.data[["value"]]))
-  } else if (to_output_type == "quantile") {
-    transform_fun <- stats::quantile
-    transform_args <- list(
-      x = quote(.data[["value"]]),
-      probs = quote(unique(.data[["output_type_id"]])),
-      names = FALSE
-    )
-  }
-
-  # if overlapping task ID cols provided, join model_out_tbl with to_output_type_id
-  # else, cross-join to avoid warnings (vector to_output_type_id elements
-  #   are coerced to data frames during validation)
-  join_cols <- task_id_cols[task_id_cols %in% colnames(to_output_type_id)]
-  if (length(join_cols) > 0) {
-    model_out_tbl <- model_out_tbl |>
-      dplyr::select(-c("output_type", "output_type_id")) |>
-      dplyr::left_join(
-        to_output_type_id,
-        by = join_cols,
-        relationship = "many-to-many"
+    output_tbl <- grouped |>
+      dplyr::summarise(
+        value = transform_fun(.data[["value"]]),
+        .groups = "drop"
+      ) |>
+      dplyr::mutate(output_type_id = NA, .before = "value")
+  } else if (length(join_cols) == 0L) {
+    # shared quantile levels: compute all of them in a single call per group.
+    # Sort and de-duplicate the levels so output type IDs are unique and, since
+    # quantiles are monotonic, the resulting values are ascending (both expected
+    # of valid hub model output).
+    probs <- sort(unique(to_output_type_id[["output_type_id"]]))
+    output_tbl <- grouped |>
+      dplyr::reframe(
+        output_type_id = probs,
+        value = stats::quantile(.data[["value"]], probs = probs, names = FALSE)
       )
   } else {
-    model_out_tbl <- model_out_tbl |>
-      dplyr::select(-c("output_type", "output_type_id")) |>
-      dplyr::cross_join(to_output_type_id)
+    # quantile levels depend on task ID variable values: attach the relevant
+    # levels as a list column (a many-to-one join, so sample rows are not
+    # duplicated) and compute per group. Levels are sorted and de-duplicated
+    # per group for the same reasons as the shared-level case above.
+    probs_by_group <- to_output_type_id |>
+      dplyr::group_by(dplyr::across(dplyr::all_of(join_cols))) |>
+      dplyr::summarise(
+        .probs = list(sort(unique(.data[["output_type_id"]]))),
+        .groups = "drop"
+      )
+    output_tbl <- model_out_tbl |>
+      dplyr::left_join(
+        probs_by_group,
+        by = join_cols,
+        relationship = "many-to-one"
+      ) |>
+      dplyr::group_by(dplyr::across(dplyr::all_of(group_cols))) |>
+      # `.probs` is identical within each group, so take the first
+      dplyr::reframe(
+        output_type_id = .data[[".probs"]][[1L]],
+        value = stats::quantile(
+          .data[["value"]],
+          probs = .data[[".probs"]][[1L]],
+          names = FALSE
+        )
+      )
   }
 
-  # compute prediction values, clean up included columns
-  model_out_tbl |>
-    dplyr::group_by(dplyr::across(dplyr::all_of(c(
-      "model_id",
-      task_id_cols,
-      otid_cols
-    )))) |>
-    dplyr::reframe(value = do.call(transform_fun, args = transform_args)) |>
+  output_tbl |>
     dplyr::mutate(
       output_type = to_output_type,
       .before = "output_type_id"

--- a/tests/testthat/test-convert_output_type.R
+++ b/tests/testthat/test-convert_output_type.R
@@ -277,3 +277,73 @@ test_that("More complex conversions from samples works", {
     dplyr::arrange(location, model_id)
   expect_equal(actual_outputs, expected_outputs)
 })
+
+test_that("quantile conversion output is invariant to the order of requested levels", {
+  sample_outputs <- create_test_sample_outputs()
+  unsorted_levels <- c(0.75, 0.25, 0.5, 0.9, 0.1)
+  canonical_levels <- sort(unsorted_levels)
+
+  unsorted_outputs <- convert_output_type(
+    sample_outputs,
+    to = list("quantile" = unsorted_levels)
+  )
+  canonical_outputs <- convert_output_type(
+    sample_outputs,
+    to = list("quantile" = canonical_levels)
+  )
+  # the requested order of levels must not affect the result: output type IDs
+  # (and therefore values) are returned ascending within each task ID group
+  expect_equal(unsorted_outputs, canonical_outputs)
+
+  task_id_cols <- subset_task_id_names(colnames(unsorted_outputs))
+  group_checks <- unsorted_outputs |>
+    dplyr::group_by(dplyr::across(dplyr::all_of(c(
+      "model_id",
+      task_id_cols
+    )))) |>
+    dplyr::summarise(
+      ids_ascending = !is.unsorted(output_type_id),
+      values_ascending = !is.unsorted(value),
+      .groups = "drop"
+    )
+  expect_true(all(group_checks$ids_ascending))
+  expect_true(all(group_checks$values_ascending))
+})
+
+test_that("duplicate requested quantile levels are de-duplicated", {
+  sample_outputs <- create_test_sample_outputs()
+  duplicated_outputs <- convert_output_type(
+    sample_outputs,
+    to = list("quantile" = c(0.5, 0.5, 0.25, 0.25, 0.75))
+  )
+  unique_outputs <- convert_output_type(
+    sample_outputs,
+    to = list("quantile" = c(0.25, 0.5, 0.75))
+  )
+  expect_equal(duplicated_outputs, unique_outputs)
+
+  # each output type ID appears at most once per task ID group (required for
+  # valid hub model output)
+  task_id_cols <- subset_task_id_names(colnames(duplicated_outputs))
+  row_counts <- duplicated_outputs |>
+    dplyr::count(dplyr::across(dplyr::all_of(
+      c("model_id", task_id_cols, "output_type_id")
+    )))
+  expect_true(all(row_counts$n == 1L))
+})
+
+test_that("task-ID-dependent quantile levels are sorted and de-duplicated per group", {
+  sample_outputs <- create_test_sample_outputs()
+  messy_levels <- rbind(
+    data.frame(location = "222", output_type_id = c(0.75, 0.25, 0.5, 0.25)),
+    data.frame(location = "888", output_type_id = c(0.9, 0.1, 0.5, 0.9))
+  )
+  clean_levels <- rbind(
+    data.frame(location = "222", output_type_id = c(0.25, 0.5, 0.75)),
+    data.frame(location = "888", output_type_id = c(0.1, 0.5, 0.9))
+  )
+  expect_equal(
+    convert_output_type(sample_outputs, to = list("quantile" = messy_levels)),
+    convert_output_type(sample_outputs, to = list("quantile" = clean_levels))
+  )
+})


### PR DESCRIPTION
Closes #282.

## Summary

`convert_output_type()` was allocating ~12x more memory (and running ~12x slower) than an equivalent `dplyr` implementation, to the point of running out of memory on large sample tables. This rewrites the inner conversion to avoid materialising a large intermediate table.

On the issue reprex (2.4M sample rows, 23 quantile levels):

| case | before | after | speedup / mem |
|---|---|---|---|
| vector quantile | 5.15s / 5.47GB | **0.22s / 0.17GB** | ~23x / ~31x |
| task-ID-dependent quantile | 5.33s / 5.65GB | **0.51s / 0.56GB** | ~10x / ~10x |
| mean | 0.10s / 0.15GB | 0.09s / 0.14GB | ~same |

## What changed

`convert_single_output_type()` now groups the samples by `model_id` + task ID columns **first** and computes the conversion per group, so the sample `value` vector is never duplicated:

- **mean / median** → `summarise()` (one value per group).
- **shared quantile levels** (vector `to`) → one `reframe()` per group calling `stats::quantile()` with the full probability vector (replaces the `cross_join`).
- **task-ID-dependent levels** (dataframe `to`) → the per-group levels are attached as a list column via a `many-to-one` join (adds a column without duplicating rows), then computed per group.

## Behaviour preservation

Quantile levels are sorted and de-duplicated per group, matching the previous behaviour and keeping output valid for `hubValidations`' ascending-value (`check_tbl_value_col_ascending`) and unique-row (`check_tbl_rows_unique`) checks. Output was verified **byte-identical** to the previous implementation (including row order) across sorted, unsorted, duplicate, mean, median, and task-ID-dependent cases.

New regression tests cover the previously-uncovered edge cases:
- output is invariant to the order of requested quantile levels (IDs/values come out ascending per group);
- duplicate requested levels are de-duplicated;
- task-ID-dependent levels are sorted and de-duplicated per group.

The grouping is unchanged (`model_id` + all task ID columns), so the samples→quantiles marginalisation semantics are identical to before.

<details>
<summary><b>Further details: what the old cross join was doing, and why dropping it is safe</b></summary>

The previous code used **one unified pipeline** for all four scenarios (mean, median, vector-quantiles, dataframe-quantiles). It unified them by always reshaping into the same form: a table with the *target* `output_type_id` column already attached, which it then grouped and collapsed.

For the vector case it attached the target levels with a cross join:

```r
model_out_tbl |>
  dplyr::select(-c("output_type", "output_type_id")) |>  # drop the sample index
  dplyr::cross_join(to_output_type_id)                    # pair every sample row with every level
```

So three sample values × three levels became nine rows, after which `group_by(model_id, task_ids, output_type_id)` + `reframe(value = quantile(value, probs = unique(output_type_id)))` collapsed each `(combo, level)` group back to a single number. The other cases reached the same shape via a `data.frame(output_type_id = NA)` (mean/median) or a join on shared task-ID columns (dataframe quantiles), then flowed through the identical tail. Tidy, single code path.

The cost: that intermediate is `n_sample_rows * n_levels` rows, duplicating the `value` column once per level, only to immediately collapse it — ~55M rows / 5.5GB on the reprex. And the expansion buys nothing computationally, because `stats::quantile()` already returns all probabilities in a single call:

```r
stats::quantile(value, probs = c(0.25, 0.5, 0.75))  # all three at once, one scan of the samples
```

So the cross join was a **uniformity device, not an algorithmic necessity**. Grouping once and calling `quantile()` with the full level vector produces the same result without ever building the intermediate — at the cost of three explicit branches instead of one shared path.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)