### PR TITLE
Release hubUtils 1.2.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: hubUtils
-Version: 1.2.0.9000
+Version: 1.2.1
 Title: Core 'hubverse' Utilities
 Authors@R: c(
     person("Anna", "Krystalli", , "annakrystalli@googlemail.com", role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# hubUtils (development version)
+# hubUtils 1.2.1
 
 * Substantially improved the performance of `convert_output_type()`. Conversions are now computed per group of model/task ID combinations without first materialising an `n_samples * n_output_type_ids` intermediate table, reducing both runtime and memory allocation by roughly an order of magnitude for large sample tables (#282, thanks @damonbayer for reporting!).
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -5,18 +5,19 @@
 Tested on:
 - Local: macOS Sequoia 15.7.2, R 4.5.1
 - GitHub Actions: macOS, Windows, Ubuntu (R-devel, release, oldrel-1)
+- win-builder: R-devel
 
-## Resubmission
+## Release summary
 
-This is a resubmission. The previous submission failed on Debian due to a test calling `arrow::s3_bucket()`. All S3-related tests now skip on CRAN.
-
-## CRAN check issues addressed
-
-This release addresses the CRAN team's email regarding graceful failure when internet resources are unavailable. Functions that access remote URLs (GitHub API, JSON configs) now use tryCatch to fail gracefully with informative error messages when resources are unavailable (#272).
+This is a patch release that substantially improves the performance of
+`convert_output_type()` by computing conversions per group of model/task ID
+combinations without first materialising a large intermediate table, reducing
+both runtime and memory allocation for large sample tables (#282).
 
 ## Reverse dependencies
 
-We checked 1 reverse dependency (hubEnsembles), comparing R CMD check results across CRAN and dev versions of this package.
+We checked 1 reverse dependency (hubEnsembles), comparing R CMD check results
+across CRAN and dev versions of this package.
 
 - We saw 0 new problems
 - We failed to check 0 packages


### PR DESCRIPTION
Release of hubUtils 1.2.1.

## Changes

* Substantially improved the performance of `convert_output_type()`. Conversions are now computed per group of model/task ID combinations without first materialising an `n_samples * n_output_type_ids` intermediate table, reducing both runtime and memory allocation by roughly an order of magnitude for large sample tables (#282, thanks @damonbayer for reporting!).

This release will be submitted to CRAN.