### PR TITLE
Add Plausible analytics to pkgdown site

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,5 +1,13 @@
 url: https://hubverse-org.github.io/hubUtils/
 template:
+  includes:
+    in_header: |
+      <!-- Privacy-friendly analytics by Plausible -->
+      <script async src="https://plausible.io/js/pa-_SeES0qkE5KfksH84IX9u.js"></script>
+      <script>
+        window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+        plausible.init()
+      </script>
   package: hubStyle
 development:
   mode: auto


### PR DESCRIPTION
Adds privacy-friendly Plausible analytics to the pkgdown documentation site by injecting the shared `hubverse-org.github.io` tracking snippet into `<head>` via `template.includes.in_header` in `_pkgdown.yml`. Part of consolidating all hubverse pkgdown sites under the single `hubverse-org.github.io` Plausible site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)